### PR TITLE
Add ctx to ExternParam

### DIFF
--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -65,7 +65,7 @@ func Prepare(proc *process.Process, arg any) error {
 		param.maxBatchSize = proc.Lim.MaxMsgSize
 	}
 	param.maxBatchSize = uint64(float64(param.maxBatchSize) * 0.6)
-	param.extern = &tree.ExternParam{}
+	param.extern = &tree.ExternParam{Ctx: proc.Ctx}
 	err := json.Unmarshal([]byte(param.CreateSql), param.extern)
 	if err != nil {
 		param.Fileparam.End = true

--- a/pkg/sql/colexec/external/external_test.go
+++ b/pkg/sql/colexec/external/external_test.go
@@ -100,6 +100,7 @@ func Test_Prepare(t *testing.T) {
 				FileService: tcs.proc.FileService,
 				Format:      tcs.format,
 				JsonData:    tcs.jsondata,
+				Ctx:         context.Background(),
 			}
 			json_byte, err := json.Marshal(extern)
 			if err != nil {
@@ -125,6 +126,7 @@ func Test_Prepare(t *testing.T) {
 						IgnoredLines: 0,
 					},
 					Format: tcs.format,
+					Ctx:    context.Background(),
 				}
 				extern.JsonData = tcs.jsondata
 				json_byte, err = json.Marshal(extern)
@@ -158,6 +160,7 @@ func Test_Call(t *testing.T) {
 				FileService: tcs.proc.FileService,
 				Format:      tcs.format,
 				JsonData:    tcs.jsondata,
+				Ctx:         context.Background(),
 			}
 			param.extern = extern
 			param.Fileparam.End = false
@@ -183,6 +186,7 @@ func Test_getCompressType(t *testing.T) {
 	convey.Convey("getCompressType succ", t, func() {
 		param := &tree.ExternParam{
 			CompressType: tree.GZIP,
+			Ctx:          context.Background(),
 		}
 		compress := getCompressType(param)
 		convey.So(compress, convey.ShouldEqual, param.CompressType)
@@ -214,6 +218,7 @@ func Test_getUnCompressReader(t *testing.T) {
 	convey.Convey("getUnCompressReader succ", t, func() {
 		param := &tree.ExternParam{
 			CompressType: tree.NOCOMPRESS,
+			Ctx:          context.Background(),
 		}
 		read, err := getUnCompressReader(param, nil)
 		convey.So(read, convey.ShouldBeNil)
@@ -429,6 +434,7 @@ func Test_GetBatchData(t *testing.T) {
 					Fields: &tree.Fields{},
 				},
 				Format: tree.CSV,
+				Ctx:    context.Background(),
 			},
 		}
 		param.Name2ColIndex = make(map[string]int32)
@@ -559,6 +565,7 @@ func TestReadDirSymlink(t *testing.T) {
 	fooPathInB := filepath.Join(root, "a", "b", "d", "foo")
 	files, err := ReadDir(&tree.ExternParam{
 		Filepath: fooPathInB,
+		Ctx:      context.Background(),
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(files))

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -539,6 +539,9 @@ func (c *Compile) compileExternScan(n *plan.Node) ([]*Scope, error) {
 	}
 
 	param.FileService = c.proc.FileService
+	if param.Ctx == nil {
+		param.Ctx = c.ctx
+	}
 	fileList, err := external.ReadDir(param)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -527,7 +527,7 @@ func (c *Compile) compileExternScan(n *plan.Node) ([]*Scope, error) {
 		mcpu = 1
 	}
 	ss := make([]*Scope, mcpu)
-	param := &tree.ExternParam{}
+	param := &tree.ExternParam{Ctx: c.ctx}
 	err := json.Unmarshal([]byte(n.TableDef.Createsql), param)
 	if err != nil {
 		return nil, err
@@ -539,9 +539,6 @@ func (c *Compile) compileExternScan(n *plan.Node) ([]*Scope, error) {
 	}
 
 	param.FileService = c.proc.FileService
-	if param.Ctx == nil {
-		param.Ctx = c.ctx
-	}
 	fileList, err := external.ReadDir(param)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fix panic
```
2022/11/18 20:47:54.469907 +0800 ERROR compile/compile.go:63 error: internal error: panic cannot create context from nil parent:
context.WithValue
    /usr/local/go/src/context/context.go:525
github.com/matrixorigin/matrixone/pkg/util/trace.ContextWithSpan
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/util/trace/context.go:31
github.com/matrixorigin/matrixone/pkg/util/trace.(*MOTracer).Start
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/util/trace/mo_trace.go:111
github.com/matrixorigin/matrixone/pkg/util/trace.Start
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/util/trace/trace.go:38
github.com/matrixorigin/matrixone/pkg/fileservice.(*S3FS).List
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/fileservice/s3_fs.go:216
github.com/matrixorigin/matrixone/pkg/sql/colexec/external.ReadDir
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/colexec/external/external.go:189
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).compileExternScan
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:542
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).compilePlanScope
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:352
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).compilePlanScope
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:375
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).compileQuery
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:228
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).compileScope
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:153
github.com/matrixorigin/matrixone/pkg/sql/compile.(*Compile).Compile
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/sql/compile/compile.go:70
github.com/matrixorigin/matrixone/pkg/frontend.(*TxnComputationWrapper).Compile
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/frontend/mysql_cmd_executor.go:2245
github.com/matrixorigin/matrixone/pkg/frontend.(*MysqlCmdExecutor).doComQuery
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/frontend/mysql_cmd_executor.go:3325
github.com/matrixorigin/matrixone/pkg/frontend.(*MysqlCmdExecutor).ExecRequest
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/frontend/mysql_cmd_executor.go:3813
github.com/matrixorigin/matrixone/pkg/frontend.(*Routine).Loop
    /Users/jacksonxie/go/src/github.com/matrixorigin/matrixone/pkg/frontend/routine.go:160
```