### PR TITLE
Span with options 1) long time threshold; 2) context deadline check

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -163,8 +163,8 @@ var (
 	//defaultCleanKillQueueInterval default: 60 minutes
 	defaultCleanKillQueueInterval = 60
 
-	// defaultLongSpanTime default: 1 s
-	defaultLongSpanTime = time.Second
+	// defaultLongSpanTime default: 10 s
+	defaultLongSpanTime = 10 * time.Second
 )
 
 // FrontendParameters of the frontend
@@ -589,7 +589,7 @@ type ObservabilityParameters struct {
 	// DisableSpan default: false. Disable span collection
 	DisableSpan bool `toml:"disableSpan"`
 
-	// LongSpanTime default: 500 ms. Only record span, which duration > LongSpanTime
+	// LongSpanTime default: 500 ms. Only record span, which duration >= LongSpanTime
 	LongSpanTime toml.Duration `toml:"longSpanTime"`
 
 	// If disabled, the logs will be written to files stored in s3

--- a/pkg/util/trace/config.go
+++ b/pkg/util/trace/config.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"io"
+	"time"
 )
 
 type TraceID [16]byte
@@ -168,6 +169,20 @@ type SpanConfig struct {
 	// remote parent span context should be ignored for security.
 	NewRoot bool `json:"NewRoot"` // WithNewRoot
 	Parent  Span `json:"-"`
+
+	// LongTimeThreshold set by WithLongTimeThreshold
+	LongTimeThreshold time.Duration `json:"-"`
+}
+
+func (c *SpanConfig) Reset() {
+	c.SpanContext.Reset()
+	c.NewRoot = false
+	c.Parent = nil
+	c.LongTimeThreshold = 0
+}
+
+func (c *SpanConfig) GetLongTimeThreshold() time.Duration {
+	return c.LongTimeThreshold
 }
 
 // SpanStartOption applies an option to a SpanConfig. These options are applicable
@@ -205,6 +220,12 @@ func WithNewRoot(newRoot bool) spanOptionFunc {
 func WithKind(kind SpanKind) spanOptionFunc {
 	return spanOptionFunc(func(cfg *SpanConfig) {
 		cfg.Kind = kind
+	})
+}
+
+func WithLongTimeThreshold(d time.Duration) SpanStartOption {
+	return spanOptionFunc(func(cfg *SpanConfig) {
+		cfg.LongTimeThreshold = d
 	})
 }
 

--- a/pkg/util/trace/impl/motrace/buffer_pipe_test.go
+++ b/pkg/util/trace/impl/motrace/buffer_pipe_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"go.uber.org/zap"
 	"strings"
 	"testing"
 	"time"
@@ -326,7 +327,7 @@ func Test_genCsvData(t *testing.T) {
 				},
 				buf: buf,
 			},
-			want: `span_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000001,,0001-01-01 00:00:00.000000,,,,{},0,,,span1,0,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000001,1000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",internal
+			want: `span_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000001,,1970-01-01 00:00:00.000001,,,,{},0,,,span1,0,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000001,1000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",internal
 `,
 		},
 		{
@@ -356,13 +357,14 @@ func Test_genCsvData(t *testing.T) {
 						Duration:   0,
 						tracer:     gTracer.(*MOTracer),
 						//EndTime:    table.ZeroTime,
+						ExtraFields: []zap.Field{zap.String("str", "field"), zap.Int64("int", 0)},
 					},
 				},
 				buf: buf,
 			},
-			want: `span_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000001,,0001-01-01 00:00:00.000000,,,,{},0,,,span1,0,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000001,1000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",statement
-span_info,node_uuid,Standalone,0000000000000002,00000000-0000-0000-0000-000000000001,,0001-01-01 00:00:00.000000,,,,{},0,,,span2,0,1970-01-01 00:00:00.000001,1970-01-01 00:00:00.001000,999000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",remote
-span_info,node_uuid,Standalone,0000000000000002,00000000-0000-0000-0000-000000000001,,0001-01-01 00:00:00.000000,,,,{},0,,,empty_end,0,1970-01-01 00:00:00.000001,0001-01-01 00:00:00.000000,0,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",remote
+			want: `span_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000001,,1970-01-01 00:00:00.000001,,,,{},0,,,span1,0,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000001,1000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",statement
+span_info,node_uuid,Standalone,0000000000000002,00000000-0000-0000-0000-000000000001,,1970-01-01 00:00:00.001000,,,,{},0,,,span2,0,1970-01-01 00:00:00.000001,1970-01-01 00:00:00.001000,999000,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",remote
+span_info,node_uuid,Standalone,0000000000000002,00000000-0000-0000-0000-000000000001,,0001-01-01 00:00:00.000000,,,,"{""str"":""field"",""int"":0}",0,,,empty_end,0,1970-01-01 00:00:00.000001,0001-01-01 00:00:00.000000,0,"{""Node"":{""node_uuid"":""node_uuid"",""node_type"":""Standalone""},""version"":""v0.test.0""}",remote
 `,
 		},
 		{

--- a/pkg/util/trace/impl/motrace/mo_trace.go
+++ b/pkg/util/trace/impl/motrace/mo_trace.go
@@ -126,6 +126,7 @@ func (s *MOSpan) Free() {
 	s.tracer = nil
 	s.ctx = nil
 	s.needRecord = false
+	s.ExtraFields = nil
 	s.StartTime = table.ZeroTime
 	s.EndTime = table.ZeroTime
 	spanPool.Put(s)
@@ -186,7 +187,7 @@ func (s *MOSpan) End(options ...trace.SpanEndOption) {
 		s.ExtraFields = append(s.ExtraFields, zap.Error(s.ctx.Err()))
 	}
 	if !s.needRecord {
-		go s.Free()
+		go freeMOSpan(s)
 		return
 	}
 	// do record
@@ -196,6 +197,10 @@ func (s *MOSpan) End(options ...trace.SpanEndOption) {
 	for _, sp := range s.tracer.provider.spanProcessors {
 		sp.OnEnd(s)
 	}
+}
+
+var freeMOSpan = func(s *MOSpan) {
+	s.Free()
 }
 
 func (s *MOSpan) AddExtraFields(fields ...zap.Field) {

--- a/pkg/util/trace/impl/motrace/mo_trace_test.go
+++ b/pkg/util/trace/impl/motrace/mo_trace_test.go
@@ -251,7 +251,8 @@ func TestMOSpan_End(t *testing.T) {
 	require.Equal(t, extraFields, longTimeSpan.(*MOSpan).ExtraFields)
 
 	// span with deadline context
-	deadlineCtx, _ := context.WithTimeout(ctx, time.Millisecond)
+	deadlineCtx, cancel := context.WithTimeout(ctx, time.Millisecond)
+	defer cancel()
 	var deadlineSpan trace.Span
 	WG.Add(1)
 	go func() {

--- a/pkg/util/trace/impl/motrace/schema.go
+++ b/pkg/util/trace/impl/motrace/schema.go
@@ -131,8 +131,8 @@ var (
 	startTimeCol    = table.DatetimeColumn("start_time", "start time")
 	endTimeCol      = table.DatetimeColumn("end_time", "end time")
 	resourceCol     = table.TextDefaultColumn("resource", `{}`, "static resource information")
-	goroutineCol    = table.TextColumn("goroutine", "progress goroutine info")
-	runtimeMemCol   = table.TextColumn("runtimeMem", "progress runtime memory info")
+	goroutineCol    = table.TextColumn("goroutine", "progress goroutine info (Reserved)")
+	runtimeMemCol   = table.TextColumn("runtimeMem", "progress runtime memory info (Reserved)")
 
 	SingleRowLogTable = &table.Table{
 		Account:  table.AccountSys,

--- a/pkg/util/trace/impl/motrace/schema.go
+++ b/pkg/util/trace/impl/motrace/schema.go
@@ -131,8 +131,6 @@ var (
 	startTimeCol    = table.DatetimeColumn("start_time", "start time")
 	endTimeCol      = table.DatetimeColumn("end_time", "end time")
 	resourceCol     = table.TextDefaultColumn("resource", `{}`, "static resource information")
-	goroutineCol    = table.TextColumn("goroutine", "progress goroutine info (Reserved)")
-	runtimeMemCol   = table.TextColumn("runtimeMem", "progress runtime memory info (Reserved)")
 
 	SingleRowLogTable = &table.Table{
 		Account:  table.AccountSys,
@@ -160,8 +158,6 @@ var (
 			durationCol,
 			resourceCol,
 			spanKindCol,
-			goroutineCol,
-			runtimeMemCol,
 		},
 		PrimaryKeyColumn: nil,
 		ClusterBy:        []table.Column{timestampCol, rawItemCol},
@@ -231,8 +227,6 @@ var (
 			durationCol,
 			resourceCol,
 			extraCol,
-			goroutineCol,
-			runtimeMemCol,
 		},
 		Condition: &table.ViewSingleCondition{Column: rawItemCol, Table: spanInfoTbl},
 	}

--- a/pkg/util/trace/impl/motrace/schema.go
+++ b/pkg/util/trace/impl/motrace/schema.go
@@ -131,6 +131,8 @@ var (
 	startTimeCol    = table.DatetimeColumn("start_time", "start time")
 	endTimeCol      = table.DatetimeColumn("end_time", "end time")
 	resourceCol     = table.TextDefaultColumn("resource", `{}`, "static resource information")
+	goroutineCol    = table.TextColumn("goroutine", "progress goroutine info")
+	runtimeMemCol   = table.TextColumn("runtimeMem", "progress runtime memory info")
 
 	SingleRowLogTable = &table.Table{
 		Account:  table.AccountSys,
@@ -158,6 +160,8 @@ var (
 			durationCol,
 			resourceCol,
 			spanKindCol,
+			goroutineCol,
+			runtimeMemCol,
 		},
 		PrimaryKeyColumn: nil,
 		ClusterBy:        []table.Column{timestampCol, rawItemCol},
@@ -226,6 +230,9 @@ var (
 			endTimeCol,
 			durationCol,
 			resourceCol,
+			extraCol,
+			goroutineCol,
+			runtimeMemCol,
 		},
 		Condition: &table.ViewSingleCondition{Column: rawItemCol, Table: spanInfoTbl},
 	}

--- a/pkg/util/trace/noop_trace.go
+++ b/pkg/util/trace/noop_trace.go
@@ -23,6 +23,7 @@ package trace
 
 import (
 	"context"
+	"go.uber.org/zap"
 )
 
 var _ TracerProvider = &noopTracerProvider{}
@@ -67,6 +68,8 @@ func (NoopSpan) ParentSpanContext() SpanContext { return SpanContext{} }
 
 // End does nothing.
 func (NoopSpan) End(...SpanEndOption) {}
+
+func (NoopSpan) AddExtraFields(...zap.Field) {}
 
 // SetName does nothing.
 func (NoopSpan) SetName(string) {}

--- a/pkg/util/trace/noop_trace.go
+++ b/pkg/util/trace/noop_trace.go
@@ -41,7 +41,7 @@ type NoopTracer struct{}
 
 // Start carries forward a non-recording Span, if one is present in the context, otherwise it
 // creates a no-op Span.
-func (t NoopTracer) Start(ctx context.Context, name string, _ ...SpanOption) (context.Context, Span) {
+func (t NoopTracer) Start(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {
 	span := SpanFromContext(ctx)
 	if _, ok := span.(NoopSpan); !ok {
 		// span is likely already a NoopSpan, but let's be sure
@@ -50,7 +50,7 @@ func (t NoopTracer) Start(ctx context.Context, name string, _ ...SpanOption) (co
 	return ContextWithSpan(ctx, span), span
 }
 
-func (t NoopTracer) Debug(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+func (t NoopTracer) Debug(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {
 	return t.Start(ctx, name, opts...)
 }
 

--- a/pkg/util/trace/noop_trace_test.go
+++ b/pkg/util/trace/noop_trace_test.go
@@ -91,7 +91,10 @@ func Test_NoopSpan_End(t *testing.T) {
 		name string
 		args args
 	}{
-		// TODO: Add test cases.
+		{
+			name: "normal",
+			args: args{in0: []SpanEndOption{}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -177,7 +180,7 @@ func Test_NoopTracer_Start(t1 *testing.T) {
 	type args struct {
 		ctx   context.Context
 		name  string
-		in2   []SpanOption
+		in2   []SpanStartOption
 		endIn []SpanEndOption
 	}
 	tests := []struct {
@@ -191,7 +194,7 @@ func Test_NoopTracer_Start(t1 *testing.T) {
 			args: args{
 				ctx:   context.Background(),
 				name:  "NoopTracer_Start",
-				in2:   []SpanOption{WithNewRoot(true)},
+				in2:   []SpanStartOption{WithNewRoot(true)},
 				endIn: []SpanEndOption{},
 			},
 			want:  ContextWithSpan(context.Background(), NoopSpan{}),
@@ -202,7 +205,7 @@ func Test_NoopTracer_Start(t1 *testing.T) {
 			args: args{
 				ctx:   ContextWithSpan(context.Background(), &NonRecordingSpan{}),
 				name:  "NoopTracer_Start",
-				in2:   []SpanOption{WithNewRoot(true)},
+				in2:   []SpanStartOption{WithNewRoot(true)},
 				endIn: []SpanEndOption{},
 			},
 			want:  ContextWithSpan(ContextWithSpan(context.Background(), &NonRecordingSpan{}), NoopSpan{}),

--- a/pkg/util/trace/trace.go
+++ b/pkg/util/trace/trace.go
@@ -26,11 +26,11 @@ import (
 	"sync/atomic"
 )
 
-func Start(ctx context.Context, spanName string, opts ...SpanOption) (context.Context, Span) {
+func Start(ctx context.Context, spanName string, opts ...SpanStartOption) (context.Context, Span) {
 	return DefaultTracer().Start(ctx, spanName, opts...)
 }
 
-func Debug(ctx context.Context, spanName string, opts ...SpanOption) (context.Context, Span) {
+func Debug(ctx context.Context, spanName string, opts ...SpanStartOption) (context.Context, Span) {
 	return DefaultTracer().Debug(ctx, spanName, opts...)
 }
 

--- a/pkg/util/trace/type.go
+++ b/pkg/util/trace/type.go
@@ -32,9 +32,9 @@ type TracerProvider interface {
 
 type Tracer interface {
 	// Start creates a span and a context.Context containing the newly-created span.
-	Start(ctx context.Context, spanName string, opts ...SpanOption) (context.Context, Span)
+	Start(ctx context.Context, spanName string, opts ...SpanStartOption) (context.Context, Span)
 	// Debug creates a span only with DebugMode
-	Debug(ctx context.Context, spanName string, opts ...SpanOption) (context.Context, Span)
+	Debug(ctx context.Context, spanName string, opts ...SpanStartOption) (context.Context, Span)
 	// IsEnable return true, means do record
 	IsEnable() bool
 }

--- a/pkg/util/trace/type.go
+++ b/pkg/util/trace/type.go
@@ -21,7 +21,10 @@
 
 package trace
 
-import "context"
+import (
+	"context"
+	"go.uber.org/zap"
+)
 
 type TracerProvider interface {
 	Tracer(instrumentationName string, opts ...TracerOption) Tracer
@@ -42,6 +45,9 @@ type Span interface {
 	// is called. Therefore, updates to the Span are not allowed after this
 	// method has been called.
 	End(options ...SpanEndOption)
+
+	// AddExtraFields inject more details for span.
+	AddExtraFields(fields ...zap.Field)
 
 	// SpanContext returns the SpanContext of the Span. The returned SpanContext
 	// is usable even after the End method has been called for the Span.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

modification:
1. logging span which is slow span, with config `longSpanTIme` as default threshold: 10s
    - user can overwirte `longSpanTime` by passing `trace.LongTimeThreshold()` at `Tracer.Start(...)`
2. logging span which meets context Deadline, and the context is specified at the `Tracer.Start`.
3. span support add ExterFields to record more detail infos.

more examples can see `TestMOSpan_End`  in [mo_trace_test.go](https://github.com/xzxiong/matrixone/pull/51/files#diff-e1f4dec1d053f37ed10baae09d769a4d40881592afb41f7e888f7c50b516cc4aR208)